### PR TITLE
Force use of standard posix shell when executing commands

### DIFF
--- a/lua/format-on-save/systemlist.lua
+++ b/lua/format-on-save/systemlist.lua
@@ -13,7 +13,7 @@ local function systemlist(cmd, input)
   end
   local stderr_tempfile = vim.fn.tempname()
   cmd = string.format("(%s) 2> %s", cmd, vim.fn.shellescape(stderr_tempfile))
-  local stdout = vim.fn.systemlist(cmd, input)
+  local stdout = vim.fn.systemlist({ "sh", "-c", cmd }, input)
 
   local stderr = {}
   if vim.fn.filereadable(stderr_tempfile) then


### PR DESCRIPTION
The `systemlist` command, when passed a string, will use the user's login shell to execute the commands. For people who use something non-posix (for example, `fish`), the command fails.

This PR forces the use of `sh` which should be present on every system.