### PR TITLE
Fix :Format command

### DIFF
--- a/lua/format-on-save/init.lua
+++ b/lua/format-on-save/init.lua
@@ -57,7 +57,7 @@ function M.setup(opts)
 
   -- Register user commands
   if opts.auto_commands ~= false then
-    vim.api.nvim_create_user_command("Format", format, {})
+    vim.api.nvim_create_user_command("Format", function() format() end, {})
     vim.api.nvim_create_user_command("FormatOn", M.enable, {})
     vim.api.nvim_create_user_command("FormatOff", M.disable, {})
   end


### PR DESCRIPTION
The `:Format` command is currently broken, as it gets passed an argument from the neovim framework which get interpreted as a (bad) formatter. This PR forces `format()` to be called with no argument.