### PR TITLE
Use vim.diff for partial_update

### DIFF
--- a/lua/format-on-save/config.lua
+++ b/lua/format-on-save/config.lua
@@ -32,7 +32,7 @@ local vim_notify = require("format-on-save.error-notifiers.vim-notify")
 ---@field enabled boolean
 ---@field debug boolean Enable extra logs for debugging (defaults to false, can also be set by setting FORMAT_ON_SAVE_DEBUG=true)
 ---@field stderr_loglevel integer The log level when a formatter was successful but included stderr output (from |vim.log.levels|, defaults to WARN)
----@field partial_update boolean Experimental feature of only updating modified lines
+---@field partial_update boolean|'diff' Experimental feature of only updating modified lines
 ---@field run_with_sh boolean Prefix all shell commands with "sh -c" (default: true)
 ---@field error_notifier ErrorNotifier How to display error messages (default: vim.notify() via require('format-on-save.notifiers.vim'))
 

--- a/lua/format-on-save/init.lua
+++ b/lua/format-on-save/init.lua
@@ -15,7 +15,7 @@ local M = {
 ---@field user_commands? boolean Add Format, FormatOn and FormatOff auto commands (defaults to true)
 ---@field debug? boolean Enable extra logs for debugging (defaults to false)
 ---@field stderr_loglevel? integer The log level when a formatter was successful but included stderr output (from |vim.log.levels|, defaults to WARN)
----@field partial_update? boolean Experimental feature of only updating modified lines
+---@field partial_update? boolean|'diff' Experimental feature of only updating modified lines
 ---@field run_with_sh? boolean Prefix all shell commands with "sh -c" (default: true)
 ---@field error_notifier? ErrorNotifier How to display error messages (default: vim.notify() via require('format-on-save.notifiers.vim'))
 
@@ -59,10 +59,13 @@ function M.setup(opts)
       end,
       group = augroup_id,
     })
-    vim.api.nvim_create_autocmd(
-      { "BufWritePost" },
-      { pattern = "*", callback = cursors.restore_current_buf_cursors, group = augroup_id }
-    )
+
+    if opts.partial_update ~= "diff" then
+      vim.api.nvim_create_autocmd(
+        { "BufWritePost" },
+        { pattern = "*", callback = cursors.restore_current_buf_cursors, group = augroup_id }
+      )
+    end
   end
 
   -- Register user commands

--- a/lua/format-on-save/update-buffer.lua
+++ b/lua/format-on-save/update-buffer.lua
@@ -3,12 +3,32 @@ local util = require("format-on-save.util")
 
 ---@param original_lines string[]
 ---@param formatted_lines string[]
-local function update_buffer(original_lines, formatted_lines)
-  if not config.partial_update then
-    vim.api.nvim_buf_set_lines(0, 0, -1, false, formatted_lines)
-    return
-  end
+local function update_buffer_with_diff(original_lines, formatted_lines)
+  local original = table.concat(original_lines, "\n") .. "\n"
+  local formatted = table.concat(formatted_lines, "\n") .. "\n"
 
+  local hunks = vim.diff(original, formatted, {
+    result_type = "indices",
+  }) --[[@as number[][] ]]
+
+  for hunk_index = vim.tbl_count(hunks), 1, -1 do
+    local hunk = hunks[hunk_index]
+    local original_start, original_count, formatted_start, formatted_count = unpack(hunk)
+
+    local formatted_hunk_lines = {}
+    for line = formatted_start, formatted_start + formatted_count - 1 do
+      table.insert(formatted_hunk_lines, formatted_lines[line])
+    end
+
+    local start_index = original_start - 1
+    local end_index = start_index + original_count
+    vim.api.nvim_buf_set_lines(0, start_index, end_index, true, formatted_hunk_lines)
+  end
+end
+
+---@param original_lines string[]
+---@param formatted_lines string[]
+local function update_buffer_line_by_line(original_lines, formatted_lines)
   if #formatted_lines < #original_lines then
     -- delete extra lines
     vim.api.nvim_buf_set_lines(0, #formatted_lines, -1, false, {})
@@ -20,6 +40,18 @@ local function update_buffer(original_lines, formatted_lines)
       vim.fn.setline(index, formatted_line)
       -- vim.api.nvim_buf_set_lines(0, index - 1, index, false, { formatted_line })
     end
+  end
+end
+
+---@param original_lines string[]
+---@param formatted_lines string[]
+local function update_buffer(original_lines, formatted_lines)
+  if config.partial_update == "diff" then
+    update_buffer_with_diff(original_lines, formatted_lines)
+  elseif config.partial_update == true then
+    update_buffer_line_by_line(original_lines, formatted_lines)
+  else
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, formatted_lines)
   end
 end
 


### PR DESCRIPTION
Hi, first of all, thank you for this plugin! I really like the way formatter configuration is done :+1: 

You have this TODO item in readme:

>Look into using vim.diff() to make the partial update smarter (only update lines that actually changed)

I tried to implement it in this pull request. But please DON'T MERGE IT YET, because there are a few things I would like to discuss first.

First of all, I'm not sure if logging should be brought back here somewhere. Right now I just removed it.

Then, I see a problem in cursor restoration autocmd right now. It effectively nullifies the benefits of partial updates, so I think it would be nice if partial update would be the only way to go. In which case cursor restoration would not be really needed and can be therefore removed. Locally I just removed that autocommand and it works nicely even with multiple windows open for the same buffer.

This works great most of the time, except in cases when cursor happens to be inside of a hunk, but even then it behaves better than it did before, where it could just scroll another window to the top until you focus it again.

Also, since null-ls was announced to be archived, I looked for different solutions to use prettier and stylua inside neovim. And I looked at other editor integrations for prettier and found this one for Emacs https://github.com/radian-software/apheleia

Interesting part about it is at the top of it's readme, where their approach is documented:

>After running the code formatter, generate an [RCS patch](https://tools.ietf.org/doc/tcllib/html/rcs.html#section4) showing the changes and then apply it to the buffer. This prevents changes elsewhere in the buffer from moving point.

^ this part is similar to what's done in this PR. The second part is about case where cursor (point in terms of Emacs) happens to be inside of a hunk.

>If a patch region happens to include point, then use a [dynamic programming algorithm for string alignment](https://en.wikipedia.org/wiki/Needleman%E2%80%93Wunsch_algorithm) to determine where point should be moved so that it remains in the same place relative to its surroundings. Finally, if the vertical position of point relative to the window has changed, adjust the scroll position to maintain maximum visual continuity. (This includes iterating through all windows displaying the buffer, if there are more than one.) The dynamic programming algorithm runs in quadratic time, which is why it is only applied if necessary and to a single patch region.

So I would suggest to implement this part as well, but I'm not sure if it should be done in this pull request or another one.

What do you think?