### PR TITLE
Properly handle empty hunks returned by vim.diff

### DIFF
--- a/lua/format-on-save/update-buffer.lua
+++ b/lua/format-on-save/update-buffer.lua
@@ -15,6 +15,17 @@ local function update_buffer_with_diff(original_lines, formatted_lines)
     local hunk = hunks[hunk_index]
     local original_start, original_count, formatted_start, formatted_count = unpack(hunk)
 
+    -- `vim.diff` returns indices of a unified diff hunks and 0 there is
+    -- considered special in that it means that hunk actuall starts on the next
+    -- line, so we take that into account here.
+    --
+    -- References:
+    --   https://www.artima.com/weblogs/viewpost.jsp?thread=164293
+    --   https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html
+    if original_count == 0 then
+      original_start = original_start + 1
+    end
+
     local formatted_hunk_lines = {}
     for line = formatted_start, formatted_start + formatted_count - 1 do
       table.insert(formatted_hunk_lines, formatted_lines[line])

--- a/tests/format-on-save/update-buffer_spec.lua
+++ b/tests/format-on-save/update-buffer_spec.lua
@@ -1,0 +1,40 @@
+local config = require("format-on-save.config")
+local update_buffer = require("format-on-save.update-buffer")
+
+local original_partial_update = config.partial_update
+
+describe('update-buffer with partial_update == "diff"', function()
+  before_each(function()
+    config.partial_update = "diff"
+  end)
+
+  after_each(function()
+    config.partial_update = original_partial_update
+  end)
+
+  it("properly handles empty hunk in a unified diff", function()
+    local original_lines = {
+      "{",
+      "",
+      "1;",
+      "",
+      "2;",
+      "}",
+    }
+
+    local formatted_lines = {
+      "{",
+      "  1;",
+      "",
+      "  2;",
+      "}",
+    }
+
+    vim.cmd("new")
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, original_lines)
+
+    update_buffer(original_lines, formatted_lines)
+
+    assert.are.same(formatted_lines, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+end)


### PR DESCRIPTION
Seems like this was the reason I broke initial implementation after moving things around, which I mentioned in a comment https://github.com/elentok/format-on-save.nvim/pull/10#issuecomment-1677086562