### PR TITLE
fix: properly handle multibyte characters

### DIFF
--- a/lua/format-on-save/update-buffer.lua
+++ b/lua/format-on-save/update-buffer.lua
@@ -2,7 +2,7 @@ local config = require("format-on-save.config")
 local refine_edits = require("format-on-save.refine-edits")
 local util = require("format-on-save.util")
 
-local NEWLINE_CHAR = vim.fn.char2nr("\n")
+local NEWLINE_CHAR = string.byte("\n")
 
 ---@class NormalizedHunk
 ---@field kind "add" | "del" | "sub"
@@ -116,7 +116,7 @@ local function convert_charwise_hunks_to_set_text_args(
   local start_col = 0
 
   local original_char_index = 1
-  local formatted_chars_str = table.concat(vim.tbl_map(vim.fn.nr2char, formatted_chars), "")
+  local formatted_chars_str = table.concat(vim.tbl_map(string.char, formatted_chars), "")
 
   ---@type NvimBufSetTextArgs[]
   local set_text_args = {}
@@ -187,12 +187,12 @@ local function update_buffer_with_charwise_diff(linewise_hunk, original_lines, f
       and charwise_hunk.add_count * charwise_hunk.del_count < 400
     then
       local original_hunk_chars = vim.tbl_map(
-        vim.fn.nr2char,
+        string.char,
         vim.list_slice(original_chars, charwise_hunk.del_start, charwise_hunk.del_end)
       )
 
       local formatted_hunk_chars = vim.tbl_map(
-        vim.fn.nr2char,
+        string.char,
         vim.list_slice(formatted_chars, charwise_hunk.add_start, charwise_hunk.add_end)
       )
 

--- a/tests/format-on-save/update-buffer_spec.lua
+++ b/tests/format-on-save/update-buffer_spec.lua
@@ -211,5 +211,21 @@ describe(
 
       assert.are.same({ 1, 18 }, vim.api.nvim_win_get_cursor(0))
     end)
+
+    it("properly handles multibyte characters", function()
+      local original_lines = {
+        "print '…'",
+      }
+
+      local formatted_lines = {
+        'print "…"',
+      }
+
+      vim.cmd("new")
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, original_lines)
+
+      update_buffer(original_lines, formatted_lines)
+      assert.are.same(formatted_lines, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+    end)
   end
 )


### PR DESCRIPTION
Neovim apis work in terms of bytes. But initially I thought that's not the case and used nr2char & char2nr to convert chars to numbers for diffing, which work in terms of unicode codepoints IIUC.