### PR TITLE
fix: tbl_islist deprecation warning (replace with islist)

### DIFF
--- a/lua/format-on-save/format.lua
+++ b/lua/format-on-save/format.lua
@@ -19,7 +19,7 @@ local function run_formatters(formatter)
   end
 
   -- Multiple formatters
-  if vim.tbl_islist(formatter) then
+  if vim.islist(formatter) then
     for _, single_formatter in ipairs(formatter) do
       run_formatters(single_formatter)
     end
@@ -78,7 +78,7 @@ local function format(formatter)
 
   -- ---@type Formatter[]
   -- local formatters
-  -- if vim.tbl_islist(formatter) then
+  -- if vim.islist(formatter) then
   --   formatters = formatter
   -- else
   --   formatters = { formatter }

--- a/lua/format-on-save/formatters/init.lua
+++ b/lua/format-on-save/formatters/init.lua
@@ -19,7 +19,7 @@ local M = {
 ---@return LazyFormatter
 function M.if_file_exists(opts, formatter_deprecated)
   -- TODO: remove this after there's no need to support the deprecated version
-  if type(opts) == "string" or (type(opts) == "table" and vim.tbl_islist(opts)) then
+  if type(opts) == "string" or (type(opts) == "table" and vim.islist(opts)) then
     vim.notify(
       "DEPRECATED: formatters.if_file_exists should be called with an options object, e.g. { pattern: '.eslintrc.*', formatter: formatters.eslint_d }",
       vim.log.levels.WARN

--- a/lua/format-on-save/systemlist.lua
+++ b/lua/format-on-save/systemlist.lua
@@ -10,7 +10,7 @@ local config = require("format-on-save.config")
 ---@param input? string[]
 ---@return CommandResult
 local function systemlist(cmd, input)
-  if type(cmd) == "table" and vim.tbl_islist(cmd) then
+  if type(cmd) == "table" and vim.islist(cmd) then
     cmd = table.concat(cmd, " ")
   end
   local stderr_tempfile = vim.fn.tempname()


### PR DESCRIPTION
I got a deprecation warning in Neovim v0.11.0-dev-1413+gf8df96d276:
```
vim.tbl_islist is deprecated use vim.islist instead
```